### PR TITLE
Code Update to address Apr 2023 S3 change 

### DIFF
--- a/cf_templates/build_deployment.yaml
+++ b/cf_templates/build_deployment.yaml
@@ -296,6 +296,9 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         RestrictPublicBuckets: true
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       VersioningConfiguration:
         Status: Enabled
       AccessControl: LogDeliveryWrite


### PR DESCRIPTION
*Issue #, if available:*
Cloudformation Stack deploy would fail on creating LoggingBucket

`Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: Amazon S3; Status Code: 400; Error Code: InvalidBucketAclWithObjectOwnership`


*Description of changes:*
Updated AWS::S3::Bucket:LoggingBucket
to include
OwnershipControls: Rules: ObjectOwnership: ObjectWriter

To address
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
